### PR TITLE
Update makefile to include DKMS.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 *.symvers
 *.mod
 .vscode
+VERSION

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,110 @@
-TARGET = tmx_driver
+# For building for the current running version of Linux
+ifndef TARGET
+TARGET = $(shell uname -r)
+endif
+# Or specific version
+#TARGET = 2.6.33.5
 
-obj-m += $(TARGET).o
+KERNEL_MODULES = /lib/modules/$(TARGET)
 
+ifneq ("","$(wildcard /usr/src/linux-headers-$(TARGET)/*)")
+# Ubuntu
+KERNEL_BUILD = /usr/src/linux-headers-$(TARGET)
+else
+ifneq ("","$(wildcard /usr/src/kernels/$(TARGET)/*)")
+# Fedora
+KERNEL_BUILD = /usr/src/kernels/$(TARGET)
+else
+KERNEL_BUILD = $(KERNEL_MODULES)/build
+endif
+endif
+
+# SYSTEM_MAP = $(KERNEL_BUILD)/System.map
+ifneq ("","$(wildcard /boot/System.map-$(TARGET))")
+SYSTEM_MAP = /boot/System.map-$(TARGET)
+else
+# Arch
+SYSTEM_MAP = /proc/kallsyms
+endif
+
+DRIVER := tmx_driver
+ifneq ("","$(wildcard .git/*)")
+# TODO: Update to use git tags when a tag is set
+DRIVER_VERSION := v0.1.$(shell git rev-parse --short HEAD)
+else
+ifneq ("", "$(wildcard VERSION)")
+DRIVER_VERSION := $(shell cat VERSION)
+else
+DRIVER_VERSION := unknown
+endif
+endif
+
+# DKMS
+DKMS_ROOT_PATH=/usr/src/$(DRIVER)-$(DRIVER_VERSION)
+MODPROBE_OUTPUT=$(shell lsmod | grep tmx_driver)
+
+# Directory below /lib/modules/$(TARGET)/kernel into which to install
+# the module:
+MOD_SUBDIR = extra
+MODDESTDIR=$(KERNEL_MODULES)/kernel/$(MOD_SUBDIR)
+
+obj-m = $(patsubst %,%.o,$(DRIVER))
+obj-ko  := $(patsubst %,%.ko,$(DRIVER))
 tmx_driver-objs += tmx.o hid_tmx.o
 
-all:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules
+MAKEFLAGS += --no-print-directory
+
+ifneq ("","$(wildcard $(MODDESTDIR)/*.ko.gz)")
+COMPRESS_GZIP := y
+endif
+ifneq ("","$(wildcard $(MODDESTDIR)/*.ko.xz)")
+COMPRESS_XZ := y
+endif
+
+
+.PHONY: all install modules modules_install clean dkms dkms_clean
+
+all: modules
+
+# Targets for running make directly in the external module directory:
+
+TMX_DRIVER_CFLAGS=-TMX_DRIVER_VERSION='\"$(DRIVER_VERSION)\"'
+
+modules:
+	@$(MAKE) EXTRA_CFLAGS="$(TMX_DRIVER_CFLAGS)" -C $(KERNEL_BUILD) M=$(CURDIR) $@
 
 clean:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) clean
+	@$(MAKE) -C $(KERNEL_BUILD) M=$(CURDIR) $@
 
-install:
-	make -C /lib/modules/$(shell uname -r)/build M=$(PWD) modules_install
+install: modules_install
+
+modules_install:
+	mkdir -p $(MODDESTDIR)
+	cp $(DRIVER).ko $(MODDESTDIR)/
+ifeq ($(COMPRESS_GZIP), y)
+	@gzip -f $(MODDESTDIR)/$(DRIVER).ko
+endif
+ifeq ($(COMPRESS_XZ), y)
+	@xz -f $(MODDESTDIR)/$(DRIVER).ko
+endif
+	depmod -a -F $(SYSTEM_MAP) $(TARGET)
+
+dkms:
+	@sed -i -e '/^PACKAGE_VERSION=/ s/=.*/=\"$(DRIVER_VERSION)\"/' dkms.conf
+	@echo "$(DRIVER_VERSION)" >VERSION
+	@mkdir -p $(DKMS_ROOT_PATH)
+	@cp `pwd`/dkms.conf $(DKMS_ROOT_PATH)
+	@cp `pwd`/VERSION $(DKMS_ROOT_PATH)
+	@cp `pwd`/Makefile $(DKMS_ROOT_PATH)
+	@cp `pwd`/hid_tmx.c $(DKMS_ROOT_PATH)
+	@cp `pwd`/tmx.c $(DKMS_ROOT_PATH)
+	@dkms add -m $(DRIVER) -v $(DRIVER_VERSION)
+	@dkms build -m $(DRIVER) -v $(DRIVER_VERSION) --kernelsourcedir=$(KERNEL_BUILD)
+	@dkms install --force -m $(DRIVER) -v $(DRIVER_VERSION)
+
+dkms_clean:
+	@if [ ! -z "$(MODPROBE_OUTPUT)" ]; then \
+		rmmod $(DRIVER);\
+	fi
+	@dkms remove -m $(DRIVER) -v $(DRIVER_VERSION) --all
+	@rm -rf $(DKMS_ROOT_PATH)

--- a/dkms.conf
+++ b/dkms.conf
@@ -1,11 +1,8 @@
-PACKAGE_NAME="tmx_driver"
-PACKAGE_VERSION="0.1"
-AUTOINSTALL="yes"
-
 SRCPATH="$dkms_tree/$module/$module_version/build"
-MAKE="make -C $kernel_source_dir M=$SRCPATH modules"
-CLEAN="make -C $kernel_source_dir M=$SRCPATH clean"
-
-
-BUILT_MODULE_NAME="tmx_driver"
-DEST_MODULE_LOCATION="/extra"
+MAKE="make TARGET=${kernelver}"
+CLEAN="make clean"
+PACKAGE_NAME="tmx_driver"
+PACKAGE_VERSION="v0.1.56d2db3"
+BUILT_MODULE_NAME[0]="tmx_driver"
+DEST_MODULE_LOCATION[0]="/extra"
+AUTOINSTALL="yes"


### PR DESCRIPTION
Allows for DKMS installation from the Makefile. Could be improved with use of release tags when identifying driver version.